### PR TITLE
Add a customisable userAgent string to the request from backstage to the wiki.

### DIFF
--- a/src/utils/axios-client.ts
+++ b/src/utils/axios-client.ts
@@ -3,12 +3,13 @@ import axiosRetry from "axios-retry";
 
 axiosRetry(axios, { retries: 3, retryDelay: axiosRetry.exponentialDelay });
 
-export const getAxiosClient = (baseURL: string, authHeaderValue: string) => {
+export const getAxiosClient = (baseURL: string, authHeaderValue: string, userAgent: string) => {
   const client = axios.create({
     baseURL,
     auth: { username: "", password: authHeaderValue },
     headers: {
       "Content-Type": "application/json",
+      "User-Agent": userAgent
     },
   });
 


### PR DESCRIPTION
Add a customisable userAgent string to the request from backstage to the wiki. This replaces the default User-Agent string of 'axios' with a value that allows easier debugging where several systems make requests with the same user agent string.